### PR TITLE
feat: make Tacotron TRT opt-in (off by default) to stop the boot-time failure

### DIFF
--- a/glados.py
+++ b/glados.py
@@ -2,6 +2,7 @@
 
 import gc
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -388,6 +389,18 @@ class TTSRunner:
         self.taco_trt = self.glados_trt is not None
         if not self.taco_trt:
             base_tacotron = self._load_tacotron_jit()
+            if os.environ.get("GLADOS_TACOTRON_TRT", "0").lower() not in ("1", "true", "yes"):
+                # Tacotron TRT is opt-in and OFF by default. The autoregressive
+                # generate_jit graph does not lower to TensorRT (it raises
+                # "RuntimeError: Dimension out of range"), so compilation always
+                # failed and fell back to eager anyway -- while logging a
+                # scary ERROR on every boot and wasting ~5s. Skip the doomed
+                # compile and use the eager path directly. Set
+                # GLADOS_TACOTRON_TRT=1 to re-enable (e.g. if the export is
+                # fixed upstream).
+                self.glados = self._optimize_tacotron_jit(base_tacotron)
+                _LOGGER.info("Tacotron engine ready. TRT=False (compile disabled)")
+                return
             _LOGGER.info("Compiling TRT tacotron...")
             self._release_cuda_cache()
             try:


### PR DESCRIPTION
## Problem
On every boot the TTS logs:
```
Compiling TRT tacotron...
[ERROR] Failed to compile TRT tacotron: … RuntimeError: Dimension out of range (expected to be in range of [-1, 0], but got 1)
Tacotron engine ready. TRT=False
```
The autoregressive `generate_jit` graph doesn't lower to TensorRT, so the compile **always** fails and falls back to eager — after wasting ~5s and logging a scary ERROR. (Consistent with the wyoming-glados note that the shipped `tacotron-trt.ts` was a mislabeled copy — Tacotron never actually ran through TRT.)

## Fix
Gate the Tacotron TRT compile behind `GLADOS_TACOTRON_TRT` (default **off**): skip the doomed compile and go straight to the eager `_optimize_tacotron_jit` path, logging `TRT=False (compile disabled)`. Set `GLADOS_TACOTRON_TRT=1` to re-enable if the export is fixed. **Vocoder TRT is untouched.**

No behavior change at inference (already eager); just removes the failed-compile boot cost + error-log noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting for Tacotron TensorRT compilation.
  * When TensorRT compilation is not enabled, the system now automatically uses the optimized standard Tacotron path.

* **Bug Fixes**
  * Prevented unnecessary TensorRT compilation attempts when no cached engine is available, improving startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->